### PR TITLE
Upgrading docker setup and adding debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Auth Service",
+      "port": 9228,
+      "remoteRoot": "/home/node",
+      "request": "attach",
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node",
+    },
+    {
+      "name": "Downstream Service",
+      "port": 9227,
+      "remoteRoot": "/home/node",
+      "request": "attach",
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:13.2.0-alpine
+FROM node:14.17.0-alpine
+
 LABEL maintainer="Anthony Hastings <ar.hastings@gmail.com>"
 
-WORKDIR /json-web-tokens
-
 RUN apk add --no-cache openssl
+
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -11,10 +11,14 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 RUN apk add --no-cache bash
 
-COPY package.json package-lock.json ./
+USER node
+
+WORKDIR /home/node
+
+COPY --chown=node package.json package-lock.json ./
 
 RUN npm install
 
-COPY . ./
+COPY --chown=node . ./
 
 CMD npm run auth-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,9 @@ services:
         environment: *shared-envs
         ports:
             - 49876:8080
+            - 9228:9228
         volumes:
-            - ./src/auth-service:/json-web-tokens/src/auth-service
+            - ./src/auth-service:/home/node/src/auth-service
     database:
         image: mongo:4.2.1
         ports:
@@ -31,5 +32,6 @@ services:
             JWKS_ENDPOINT: http://auth-service:8080/.well-known/jwks.json
         ports:
             - 49877:8080
+            - 9227:9227
         volumes:
-            - ./src/downstream-service:/json-web-tokens/src/downstream-service
+            - ./src/downstream-service:/home/node/src/downstream-service

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "main": "src/auth-service/index.mjs",
   "scripts": {
-    "auth-service": "nodemon --exec babel-node -- src/auth-service/index.mjs",
-    "downstream-service": "nodemon --exec babel-node -- src/downstream-service/index.mjs",
+    "auth-service": "nodemon --exec babel-node --inspect=0.0.0.0:9228 -- src/auth-service/index.mjs",
+    "downstream-service": "nodemon --exec babel-node --inspect=0.0.0.0:9227 -- src/downstream-service/index.mjs",
     "lint": "eslint --ext js --ext mjs src/"
   },
   "devDependencies": {


### PR DESCRIPTION
Highlights:
- [Docker] Upgrading Node version from an unsupported release (v13) to an Active LTS release (v14).
- [Docker] Ensuring that we use the less privileged `node` user and their home directory on the docker container, and that we're copying files over belong to said `node` user rather than root.
- [Debugger] Adding `launch.json` to configure how VS Code will attach to debuggers. Note that `remoteRoot` is very important as whenever a breakpoint triggers within a particular file on the container, VS Code has to know how to map that remote file (e.g. `/home/node/src/auth-service/index.mjs`) to the locally within your project.
- [Debugger] Updating node commands for services to invoke a process that listens for debugging clients connecting. The process gets bound to `0.0.0.0` (for visibility on host machine) and on a particular port. These ports are also exposed to host machine in `docker-compose.yml`.

More Information:
  - [Node.js debugging in VS Code](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_remote-debugging)
  - [Setting up Debugger for Node.js in Docker with VS code](https://blog.theodo.com/2018/10/setting-debugger-node-js-docker-vs-code/)
  - [Debug Node.js app running in a Docker container](https://www.bigbinary.com/blog/debug-nodejs-app-running-in-a-docker-container)