### PR TITLE
Adding mitmproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,31 @@ The entire application is dockerized so ensure that _Docker_ and _Docker Compose
 docker-compose up
 ```
 
-Watch for terminal output to indicate that both web services and the database service have started. The Auth Service can be reached at [http://localhost:49876](http://localhost:49876) and the Downstream Service can be reached at [http://localhost:49877](http://localhost:49877).
+Watch for terminal output to indicate that web services, proxy services and the database service have started. Services can be accessed in the following ways:
+
+| Service            | Port (Direct) | Port (Proxy) | Proxy (Web Viewer) |
+| ------------------ | ------------- | ------------ | ------------------ |
+| Auth Service       | 49802         | 49801        | 5000               |
+| Downstream Service | 49804         | 49803        | 5001               |
+| Database Service   | 49800         | N/A          | N/A                |
+
+Accessing the web services via the proxy port will mean you can see and example the traffic by visiting the proxy web viewer port in your browser.
 
 ## Explanation / Demonstration
 The Auth Service loads in a dummy private RSA-encoded PEM (not indicative of how a private key in a production environment would be loaded) and uses it to generate a JSON Web Key. This JWK is made available at a JWKS endpoint for other services to load and use for token verification purposes. If downstream services were to use the private key for verification that was used to originally sign the token, then downstream services would also be able to mint their own tokens, which is not ideal. We want that privilege to live only with our Auth service. This is how JWKS can ensure our Auth Service is the only service that can mint tokens (as it is the only service with access to the private key), but that every other service can verify tokens by generating a public key for the relevant JWK exposed via the JWKS endpoint.
 
-To make interacting with the API easier, it's recommended to use a tool such as [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en). Postman makes setting headers and request bodies much easier to deal with. I have exported all necessary requests into Postman, available below:
+To make interacting with the API easier, it's recommended to use a tool such as [Postman](https://www.postman.com/). Postman makes setting headers and request bodies much easier to deal with. I have exported all necessary requests into Postman, available below:
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1ea58c6930a22e603a8e)
+[Postman Collection](https://www.getpostman.com/collections/fa7a31a47fea849412d0)
 
 The flow for running these commands should be as follows:
 
-1. Trigger the "Auth Service - Myself (Authenticated)" call and observe the resulting `401` response due to supplying an expired JWT.
-1. Trigger the "Auth Service - Register" endpoint (which is pre-populated with credentials) to make a `User` record.
-1. Trigger the "Auth Service - Authenticate" (which is pre-populated with credentials) to generate a JWT token with a lifespan of 30s, containing the relevant `User` record.
-1. Take the token returned from the "Auth Service - Authenticate" endpoint and set it as the `x-access-token` header of the "Auth Service - Myself (Authenticated)" call. Run the call and see the `User` record returned.
-1. Use the same token from above and set it as the `x-access-token` header of the "Downstream Service - Myself (Authenticated)" call. Run the call and see the `User` record returned.
-1. Wait over 30 seconds and re-run the above "Downstream Service - Myself (Authenticated)" call. You will now see a `401` error because the JWT token has expired and is invalid.
+1. Trigger the "Auth Service (Proxy) - Myself" call and observe the resulting `401` response due to supplying an expired JWT.
+1. Trigger the "Auth Service (Proxy) - Register" endpoint (which is pre-populated with credentials) to make a `User` record.
+1. Trigger the "Auth Service (Proxy) - Authenticate" (which is pre-populated with credentials) to generate a JWT token with a lifespan of 30s, containing the relevant `User` record.
+1. Take the token returned from the "Auth Service (Proxy) - Authenticate" endpoint and set it as the `x-access-token` header of the "Auth Service (Proxy) - Myself" call. Run the call and see the `User` record returned.
+1. Use the same token from above and set it as the `x-access-token` header of the "Downstream Service (Proxy) - Myself" call. Run the call and see the `User` record returned.
+1. Wait over 30 seconds and re-run the above "Downstream Service (Proxy) - Myself" call. You will now see a `401` error because the JWT token has expired and is invalid.
 
 ## Further Information
 - [JSON Web Token Introduction](https://jwt.io/introduction/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 version: '3.7'
+
 x-shared-envs:
     &shared-envs
     MONGODB_URL: mongodb://database:27017
     KID: kid-123
+
 services:
     auth-service:
         build:
@@ -12,26 +14,46 @@ services:
             - database
         environment: *shared-envs
         ports:
-            - 49876:8080
+            - 49802:8080
             - 9228:9228
         volumes:
             - ./src/auth-service:/home/node/src/auth-service
+
+    auth-service-proxy:
+        image: mitmproxy/mitmproxy
+        command: sh -c "mitmweb --mode upstream:auth-service:8080 --listen-host 0.0.0.0 --listen-port 80 --web-host 0.0.0.0 --web-port 3000 --no-web-open-browser"
+        depends_on:
+            - auth-service
+        ports:
+            - 49801:80
+            - 5000:3000
+
     database:
         image: mongo:4.2.1
         ports:
-            - 49875:27017
+            - 49800:27017
+
     downstream-service:
         build:
           context: ./
-        command: sh -c "dockerize -wait tcp://database:27017 -wait tcp://auth-service:8080 npm run downstream-service"
+        command: sh -c "dockerize -wait tcp://database:27017 -wait tcp://auth-service-proxy:80 npm run downstream-service"
         depends_on:
-            - auth-service
+            - auth-service-proxy
             - database
         environment:
             << : *shared-envs
-            JWKS_ENDPOINT: http://auth-service:8080/.well-known/jwks.json
+            JWKS_ENDPOINT: http://auth-service-proxy:80/.well-known/jwks.json
         ports:
-            - 49877:8080
+            - 49804:8080
             - 9227:9227
         volumes:
             - ./src/downstream-service:/home/node/src/downstream-service
+
+    downstream-service-proxy:
+        image: mitmproxy/mitmproxy
+        command: sh -c "mitmweb --mode upstream:downstream-service:8080 --listen-host 0.0.0.0 --listen-port 80 --web-host 0.0.0.0 --web-port 3000 --no-web-open-browser"
+        depends_on:
+            - downstream-service
+        ports:
+            - 49803:80
+            - 5001:3000


### PR DESCRIPTION
This PR adds `mitmproxy` to demonstrate using an "Upstream Proxy" technique where anything hitting the proxy is forwarded to an upstream host. The purpose of this is for logging the request / responses and debugging accordingly.

Detailed Breakdown:
- Adding two new containers; `auth-service-proxy` and `downstream-service-proxy`. These services expose their 'web port' to view their traffic in a browser, and also expose their 'listening port' which is where traffic intended for the relevant upstream service should be directed to.
- Updating any host references amongst the services (e.g. `JWKS_ENDPOINT` on Downstream Service) to point at the proxies rather than directly at the services.

![Peek 2021-09-01 23-24](https://user-images.githubusercontent.com/167421/131753294-c4daeff8-930a-433a-ab56-f3b96e4215b8.gif)
